### PR TITLE
Create the outputFile if it doesn't exist, including parent directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 
-var fs = require("fs");
+var fs = require("fs-extra");
 var chalk = require("chalk");
 var partialUtils = require("./utils/partials");
 var Handlebars = require("handlebars");
@@ -104,7 +104,7 @@ HandlebarsPlugin.prototype.apply = function (compiler) {
         if (options.onBeforeSave) {
             result = options.onBeforeSave(Handlebars, result) || result;
         }
-    	fs.writeFileSync(outputFile, result, "utf-8");
+    	fs.outputFileSync(outputFile, result, "utf-8");
 
         console.log(chalk.green(outputFile + " created"));
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/sagold/handlebars-webpack-plugin",
   "dependencies": {
     "chalk": "^1.1.1",
+    "fs-extra": "^0.26.7",
     "glob": "^5.0.15",
     "handlebars": "^4.0.3"
   }


### PR DESCRIPTION
In Node, `fs#writeFileSync` creates files, but not parent directories.
