### PR TITLE
WDS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,10 @@ class HandlebarsPlugin {
             this.addDependency(helper.filepath);
         });
 
+        this.registerPartials();
+    }
+
+    registerPartials() {
         // register partials
         const partials = partialUtils.resolve(Handlebars, this.options.partials);
         this.options.onBeforeAddPartials(Handlebars, partials);
@@ -87,6 +91,8 @@ class HandlebarsPlugin {
     }
 
     compileEntryFile(filepath) {
+        // Refresh partials
+        this.registerPartials();
         const targetFilepath = getTargetFilepath(filepath, this.options.output);
         // fetch template content
         let templateContent = this.readFile(filepath, "utf-8");


### PR DESCRIPTION
I was trying to use this plugin with Webpack Dev Server and found out that the partials are only once read from disk — when the plugin instance is created. So when we changed the partials the compiled file did not change. I made it work for us by registering the partials on every compile.

This may need some refining before being accepted into this project, e.g. should `onBeforeAddPartials` be called every time, etc. So I just decided to create this PR and have the discussion here.