### PR TITLE
Output defaults

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+# v1.0.0 - 17/03/31
+
+- Refactor to es6 (drops support for nodejs versions < 6)
+
+# v0.2.0 - 17/03/31
+
+- Added support for multiple entry files

--- a/index.js
+++ b/index.js
@@ -9,11 +9,17 @@ const log = require("./utils/log");
 
 
 function getTargetFilepath(filepath, outputTemplate) {
-    const fileName = path
-        .basename(filepath)
-        .replace(path.extname(filepath), "");
-
-    return outputTemplate.replace("[name]", fileName);
+    let outputFilepath;
+    if (outputTemplate) {
+        const fileName = path
+          .basename(filepath)
+          .replace(path.extname(filepath), "");
+        outputFilepath = outputTemplate.replace("[name]", fileName);
+    } else {
+        outputFilepath = filepath.replace(path.extname(filepath), "");
+    }
+    
+    return outputFilepath;
 }
 
 


### PR DESCRIPTION
Hi,
I was using `handlebars-webpack-plugin` to migrate a project from grunt to webpack, one of the requirements is compile several handlebars templates spread over the project, where this plugin fits very well, the issue I had was that I need each output right next to the each entry, for this reason I made some changes so when no output is defined in the plugin the output defaults to the same entry path of each file.

This may need some refining before being accepted into this project, but I hope this can bring more ideas and options about how to handle entries and outputs.

Thanks