### PR TITLE
Add webpack-html-plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ var webpackConfig = {
                 nameOfHbsHelper: Function.prototype,
                 projectHelpers: path.join(process.cwd(), "app", "helpers", "*.helper.js")
             },
-
+            // if you want to start rendering handlebars after the html-webpack-plugin
+            // has finished set this to true
+            htmlWebpackPlugin: false,
             // hooks
             onBeforeSetup: function (Handlebars) {},
             onBeforeAddPartials: function (Handlebars, partialsMap) {},
@@ -66,3 +68,37 @@ Use handlebars in your main and partials like, i.e.
 </body>
 ```
 
+
+## Html Webpack Plugin
+
+You can use this plugin to generate a `head.hbs` with the [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)
+and use this partial as an input for other handlebar templates.
+
+```js
+plugins: [
+   new HtmlWebpackPlugin({
+      title: 'Generic Head Title',
+      // the output file name
+      filename: path.join(__dirname, 'dist', 'partials', 'head.hbs'),
+      // the head template you want to use
+      template: path.join(__dirname, 'src', 'hbs', 'partials_generate', 'head.hbs'),
+      inject: 'head'
+    }),
+    new HandlebarsPlugin({
+      htmlWebpackPlugin: true,
+      // path to hbs entry file(s)
+      entry: path.join(process.cwd(), 'src', 'hbs', 'site', '*.hbs'),
+      // output path and filename(s). This should lie within the webpacks output-folder
+      // if ommited, the input filepath stripped of its extension will be used
+      // data passed to main hbs template: `main-template(data)`
+      output: path.join(process.cwd(), 'dist', "[name].html"),
+
+      partials: [
+          // the dist folder where the generated hbs file can be found
+          path.join(process.cwd(), 'dist', '*', '*.hbs'),
+          // other partials
+          path.join(process.cwd(), 'src', 'hbs', '*', '*.hbs')
+      ]
+  })
+]
+```

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ class HandlebarsPlugin {
             output: null,
             data: {},
             helpers: {},
+            htmlWebpackPlugin: false,
             onBeforeSetup: Function.prototype,
             onBeforeAddPartials: Function.prototype,
             onBeforeCompile: Function.prototype,
@@ -102,8 +103,17 @@ class HandlebarsPlugin {
         };
 
         if (compiler.hooks) {
-            compiler.hooks.make.tapAsync("HandlebarsRenderPlugin", compile);
-            compiler.hooks.emit.tapAsync("HandlebarsRenderPlugin", emitDependencies);
+            // tap into the webpack html plugin hooks
+            if(this.options.htmlWebpackPlugin) {
+                compiler.hooks.compilation.tap('HtmlWebpackPluginHooks', compilation => {
+                    compilation.hooks.htmlWebpackPluginAfterEmit.tapAsync("HandlebarsRenderPlugin", (_, done) =>  compile(compilation, done));
+                });
+                compiler.hooks.emit.tapAsync("HandlebarsRenderPlugin", emitDependencies);
+            } else {
+                // use standard compiler hooks
+                compiler.hooks.make.tapAsync("HandlebarsRenderPlugin", compile);
+                compiler.hooks.emit.tapAsync("HandlebarsRenderPlugin", emitDependencies);
+            }
         } else {
             // @legacy wp < v4
             compiler.plugin("make", compile);

--- a/index.js
+++ b/index.js
@@ -105,10 +105,10 @@ class HandlebarsPlugin {
         if (compiler.hooks) {
             // tap into the webpack html plugin hooks
             if(this.options.htmlWebpackPlugin) {
-                compiler.hooks.compilation.tap('HtmlWebpackPluginHooks', compilation => {
+                compiler.hooks.afterEmit.tap('HandlebarsRenderPlugin', compilation => {
                     compilation.hooks.htmlWebpackPluginAfterEmit.tapAsync("HandlebarsRenderPlugin", (_, done) =>  compile(compilation, done));
+                    compilation.hooks.htmlWebpackPluginAfterEmit.tapAsync("HandlebarsRenderPlugin", (_, done) =>  emitDependencies(compilation, done));
                 });
-                compiler.hooks.emit.tapAsync("HandlebarsRenderPlugin", emitDependencies);
             } else {
                 // use standard compiler hooks
                 compiler.hooks.make.tapAsync("HandlebarsRenderPlugin", compile);


### PR DESCRIPTION
This commit adds support for the html-webpack-plugin. It compiles the handlebar templates after the html-webpack-plugin hooks have been triggered. This allows users to generate handlebar partials with the html-webpack-plugin that can later be consumed by the handlebars-wepback-plugin.