### PR TITLE
Added glob support for JSON data files

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,16 +233,28 @@ class HandlebarsPlugin {
      */
     updateData() {
         if (this.options.data && typeof this.options.data === "string") {
-            try {
-                const dataFromFile = JSON.parse(this.readFile(this.options.data));
-                this.addDependency(this.options.data);
-                this.data = dataFromFile;
-            } catch (e) {
-                console.error(`Tried to read ${this.options.data} as json-file and failed. Using it as data source...`);
-                this.data = this.options.data;
-            }
+            this.data = {};
+            const entryFilesArray = glob.sync(this.options.data);
+            entryFilesArray.forEach((filePath) => {
+                this.readDataFile(filePath);
+            });
         } else {
             this.data = this.options.data;
+        }
+    }
+
+    /**
+     * Read a JSON file for input data
+     * @param  {string} filePath    - path to the file
+     */
+    readDataFile(filePath) {
+        try {
+            const dataFromFile = JSON.parse(this.readFile(filePath));
+            this.addDependency(filePath);
+            const dataKey = path.basename(filePath, ".json");
+            this.data[dataKey] = dataFromFile;
+        } catch (e) {
+            console.error(`Tried to read ${filePath} as json-file and failed. Using it as data source...`);
         }
     }
 


### PR DESCRIPTION
Adds glob support for data files. It works by producing a data object using file names as keys.
This is a breaking change however... Unless we put in a check for single file results and change the data structure accordingly.

This may need some more work to support nested data folders. e.g. `data/folder/file.json`.

Happy to discuss.

Usage
```
new HandlebarsPlugin({
      entry: path.join(__dirname, 'src', 'views', '*.hbs'),
      data: path.join(__dirname, 'src', 'data', '*.json'),
})
```

Example
```
// src/data/home.json
{
  "title": "Home"
}

// src/data/about.json
{
  "title": "About"
}

// handlebars data
{
  "home": {
    "title": "Home"
  },
  "about": {
    "title": "About"
  },
}

// src/views/home.hbs
<body>
  <h1>{{home.title}}</h1>
</body>

// dist/home.html
<body>
  <h1>Home</h1>
</body>
```

Related: #37 