### PR TITLE
Add option to override getTargetFilepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ var webpackConfig = {
       },
 
       // hooks
+      getTargetFilepath: function (filepath, outputTemplate) {},
       onBeforeSetup: function (Handlebars) {},
       onBeforeAddPartials: function (Handlebars, partialsMap) {},
       onBeforeCompile: function (Handlebars, templateContent) {},

--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ plugins: [
 
     htmlWebpackPlugin: {
     enabled: true, // register all partials from html-webpack-plugin, defaults to `false`
-    prefix: "html" // default is "html"
+    prefix: "html" // where to look for htmlWebpackPlugin output. default is "html"
     },
 
     entry: path.join(process.cwd(), "src", "hbs", "*.hbs"),
     output: path.join(process.cwd(), "dist", "[name].html"),
 
     partials: [
-      path.join(process.cwd(), "dist", "*", "*.hbs"),
+      path.join(process.cwd(), "html",/* <-- this should match htmlWebpackPlugin.prefix */ "*", "*.hbs"),
       path.join(process.cwd(), "src", "hbs", "*", "*.hbs")
     ]
   })

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ class HandlebarsPlugin {
             entry: null,
             output: null,
             data: {},
+            getTargetFilepath,
             helpers: {},
             htmlWebpackPlugin: null,
             onBeforeSetup: Function.prototype,
@@ -278,7 +279,7 @@ class HandlebarsPlugin {
      * @param  {String} outputPath  - webpack output path for build results
      */
     compileEntryFile(sourcePath, outputPath) {
-        let targetFilepath = getTargetFilepath(sourcePath, this.options.output);
+        let targetFilepath = this.options.getTargetFilepath(sourcePath, this.options.output);
         // fetch template content
         let templateContent = this.readFile(sourcePath, "utf-8");
         templateContent = this.options.onBeforeCompile(Handlebars, templateContent) || templateContent;

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ class HandlebarsPlugin {
         }, options);
 
         // setup htmlWebpackPlugin default options and merge user configuration
-        this.options.htmlWebpackPlugin = Object.assign({ enabled: false, prefix: "html" }, options.htmlWebpackPlugin);
+        this.options.htmlWebpackPlugin = Object.assign({ enabled: false, prefix: "html" }, options.htmlWebpackPlugin.toString() === "true" ? {enabled: true} : options.htmlWebpackPlugin);
 
         this.firstCompilation = true;
         this.options.onBeforeSetup(Handlebars);


### PR DESCRIPTION
This PR adds an option to provide a custom `getTargetFilepath' function.
Currently, you only can
* create files with parent path, but without extension (no outputTemplate specified)
* create files without parent path, with/without extension (outputTemplate specified).

I want to create files in the dist folder, including the parent path and file extension.
With a custom `getTargetFilepath' function, this is possible.