### PR TITLE
Enable windows support for htmlWebpackPlugin generated partials

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,8 +113,10 @@ class HandlebarsPlugin {
                 compiler.hooks.compilation.tap("HtmlWebpackPluginHooks", (compilation) => {
                     compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tap("HandlebarsRenderPlugin", (data) => {
                         // @todo used a new partial helper to check for an existing partial
+                        // @todo use generate id for consistent name replacements
+
                         Handlebars.registerPartial(
-                            `${prefix}/${partialUtils.getId(data.outputName)}`,
+                            `${prefix}/${data.outputName.replace(/\.[^.]*$/, "").replace("\\", "/")}`,
                             data.html
                         );
 

--- a/index.js
+++ b/index.js
@@ -113,9 +113,8 @@ class HandlebarsPlugin {
                 compiler.hooks.compilation.tap("HtmlWebpackPluginHooks", (compilation) => {
                     compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tap("HandlebarsRenderPlugin", (data) => {
                         // @todo used a new partial helper to check for an existing partial
-                        // @todo use generate id for consistent name replacements
                         Handlebars.registerPartial(
-                            `${prefix}/${data.outputName.replace(/\.[^.]*$/, "")}`,
+                            `${prefix}/${partialUtils.getId(data.outputName)}`,
                             data.html
                         );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars-webpack-plugin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Renders your html-template on build time",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
~~Replaced the manual regex string replacement with partialUtils.getId() to resolve partial name.~~
Added an extra replace() to support windows paths in data.outputName