### PR TITLE
fix: duplicate declared file dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ class HandlebarsPlugin {
      * @return {String} filecontents
      */
     readFile(filepath) {
-        this.fileDependencies.push(filepath);
+        this.addDependency(filepath);
         return fs.readFileSync(filepath, "utf-8");
     }
 
@@ -163,7 +163,11 @@ class HandlebarsPlugin {
      * @param {...[String]} args    - list of filepaths
      */
     addDependency(...args) {
-        this.fileDependencies.push.apply(this.fileDependencies, args.filter((filename) => filename));
+        if (!args) return;
+        args.forEach(filename => {
+            if (filename && !this.fileDependencies.includes(filename))
+                this.fileDependencies.push(filename);
+        });
     }
 
     /**


### PR DESCRIPTION
This PR fixes a small performance issue I encountered while debugging.
File dependencies are declared multiple times.