### PR TITLE
add option to override partial ID determination

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ class HandlebarsPlugin {
             entry: null,
             output: null,
             data: {},
+            getPartialId: partialUtils.getDefaultId,
             helpers: {},
             htmlWebpackPlugin: null,
             onBeforeSetup: Function.prototype,
@@ -68,7 +69,7 @@ class HandlebarsPlugin {
      */
     loadPartials() {
         // register partials
-        const partials = partialUtils.resolve(Handlebars, this.options.partials);
+        const partials = partialUtils.resolve(Handlebars, this.options.partials, this.options.getPartialId);
         this.options.onBeforeAddPartials(Handlebars, partials);
         partialUtils.addMap(Handlebars, partials);
         // watch all partials for changes

--- a/utils/partials.js
+++ b/utils/partials.js
@@ -4,11 +4,11 @@ const chalk = require("chalk");
 const log = require("./log");
 
 
-function getId(path) {
+function getDefaultId(path) {
     return path.match(/\/([^/]+\/[^/]+)\.[^.]+$/).pop();
 }
 
-function resolve(Handlebars, partialsGlob) {
+function resolve(Handlebars, partialsGlob, getId) {
     let partials = [];
 
     if (partialsGlob == null) {
@@ -36,8 +36,7 @@ function addMap(Handlebars, partialMap) {
 
 
 module.exports = {
-
-    getId,
+    getDefaultId,
     resolve,
     addMap
 };


### PR DESCRIPTION
Adds an option to override how partial IDs are created.

This gives you the ability to have a folder structure of partials, like this:
```
src
  partial
    de
      top.hbs
      bottom.hbs
    en
      top.hbs
      bottom.hbs
```

With a configuation like this:
```
partials: [path.join(process.cwd(), "src/partial/**/*.hbs")],
getPartialId: path => path.replace(/^.*\/src\/partial\/(.*)\.[^.]+$/, "$1"),
```
a partial at `src/partial/en/header.hbs` would become ID `en/header`.