### PR TITLE
Add ability to parse and convert nested .hbs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const webpackConfig = {
   plugins: [
 
     new HandlebarsPlugin({
-      // path to hbs entry file(s)
+      // path to hbs entry file(s). Also supports nested directories if write path.join(process.cwd(), "app", "src", "**", "*.hbs"),
       entry: path.join(process.cwd(), "app", "src", "*.hbs"),
       // output path and filename(s). This should lie within the webpacks output-folder
       // if ommited, the input filepath stripped of its extension will be used
@@ -160,62 +160,62 @@ plugins: [
 ## Contributors
 
 <a href="https://github.com/TheReincarnator">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="TheReincarnator" src="https://avatars0.githubusercontent.com/u/840370?s=460&v=4">
 </a>
 
 <a href="https://github.com/muuki88">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="muuki88" src="https://avatars2.githubusercontent.com/u/647727?s=460&v=4">
 </a>
 
 <a href="https://github.com/emilchristensen">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="emilchristensen" src="https://avatars3.githubusercontent.com/u/575486?s=460&v=4">
 </a>
 
 <a href="https://github.com/alisonailea">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="alisonailea" src="https://avatars2.githubusercontent.com/u/3362490?s=460&v=4">
 </a>
 
 <a href="https://github.com/vredondoGL">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="vredondoGL" src="https://avatars3.githubusercontent.com/u/35344609?s=460&v=4">
 </a>
 
 <a href="https://github.com/mkungla">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="mkungla" src="https://avatars2.githubusercontent.com/u/15878458?s=460&v=4">
 </a>
 
 <a href="https://github.com/bywo">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="bywo" src="https://avatars2.githubusercontent.com/u/1434481?s=460&v=4">
 </a>
 
 <a href="https://github.com/baldurh">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="baldurh" src="https://avatars3.githubusercontent.com/u/1823617?s=460&v=4">
 </a>
 
 <a href="https://github.com/DannyDelott">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="DannyDelott" src="https://avatars3.githubusercontent.com/u/4524175?s=460&v=4">
 </a>
 
 <a href="https://github.com/amandabouveng">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="amandabouveng" src="https://avatars2.githubusercontent.com/u/15197360?s=460&v=4">
 </a>
 
 <a href="https://github.com/patrikniebur">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="patrikniebur" src="https://avatars0.githubusercontent.com/u/6452693?s=460&v=4">
 </a>
 
 <a href="https://github.com/mitchheddles">
-    <img width="80" height="80" style="max-width:100%;" 
+    <img width="80" height="80" style="max-width:100%;"
         title="mitchheddles" src="https://avatars2.githubusercontent.com/u/20656128?s=460&v=4">
 </a>
 

--- a/index.js
+++ b/index.js
@@ -309,7 +309,33 @@ class HandlebarsPlugin {
     compileEntryFile(sourcePath, outputPath) {
         outputPath = sanitizePath(outputPath);
 
-        let targetFilepath = this.options.getTargetFilepath(sourcePath, this.options.output);
+        const domen = this.options.entry.split('*')[0];
+        // array of all path elements except the relative ones (**|*)
+        const rootArray = domen.split(path.sep);
+        const rootFolderName = rootArray[rootArray.length - 2];
+        const partials = this.options.partials;
+
+        if (partials) {
+            let isPartialsPath = false;
+
+            partials.forEach((partial) => {
+                const partialRootIndex = partial.split(path.sep).indexOf(rootFolderName) + 1;
+                // partial folder name
+                const partialFolderName = partial.split(path.sep)[partialRootIndex];
+                // current source folder name
+                const folderName = path.dirname(sourcePath).split(path.sep)[partialRootIndex];
+                // ignore partial
+                if (folderName === partialFolderName) {
+                    isPartialsPath = true;
+                }
+            });
+
+            if (isPartialsPath) {
+                return;
+            }
+        }
+
+        let targetFilepath = this.options.getTargetFilepath(sourcePath, rootFolderName, this.options.output);
         // fetch template content
         let templateContent = this.readFile(sourcePath, "utf-8");
         templateContent = this.options.onBeforeCompile(Handlebars, templateContent) || templateContent;

--- a/utils/getTargetFilepath.js
+++ b/utils/getTargetFilepath.js
@@ -2,19 +2,24 @@ const path = require("path");
 
 
 /**
- * Returns the target filepath of a handlebars template
- * @param  {String} filepath            - input filepath
- * @param  {String} [outputTemplate]    - template for output filename.
- *                                          If ommited, the same filename stripped of its extension will be used
- * @return {String} target filepath
+ * Returns the target filePath of a handlebars template
+ * @param  {String} filePath            - input filePath
+ * @param  {String} rootPath            - input rootPath
+ * @param  {String} [outputTemplate]    - template for output filename. If ommited, the same filename stripped of its extension will be used
+ * @return {String} target filePath
  */
-module.exports = function getTargetFilepath(filepath, outputTemplate) {
+module.exports = function getTargetFilepath(filePath, rootPath, outputTemplate) {
     if (outputTemplate == null) {
-        return filepath.replace(path.extname(filepath), "");
+        return filePath.replace(path.extname(filePath), "");
     }
 
+    const folderPath = path
+        .dirname(filePath)
+        .split(rootPath)[1];
+
     const fileName = path
-        .basename(filepath)
-        .replace(path.extname(filepath), "");
-    return outputTemplate.replace("[name]", fileName);
+        .basename(filePath)
+        .replace(path.extname(filePath), "");
+
+    return outputTemplate.replace("[name]", path.join(folderPath, fileName));
 };


### PR DESCRIPTION
**The reason:**
Now plugin is parsing only 1st level templates inside directory (plane structure). 

**My offer:**
In my project I'm using a lot of nested subdirectories and for this reason I've made customized version of plugin to support it. I think it's very important to add ability to parse nested directories with `.hbs` templates especially if it doesn't break current API.
So now `entry: path.join(process.cwd(), "app", "src", "**", "*.hbs")` will convert whole tree of files.