### PR TITLE
fix: Watch and build for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ class HandlebarsPlugin {
 
     /**
      * Notifies webpack-dev-server of generated files
-     * @param  {Compilation} compilation
+     * @param  {Object} compilation
      */
     emitGeneratedFiles(compilation) {
         Object.keys(this.assetsToEmit).forEach(filename => {
@@ -265,7 +265,7 @@ class HandlebarsPlugin {
     /**
      * @async
      * Generates all given handlebars templates
-     * @param  {String} compilation  - webpack compilation
+     * @param  {Object} compilation  - webpack compilation
      * @param  {Function} done
      */
     compileAllEntryFiles(compilation, done) {
@@ -286,7 +286,7 @@ class HandlebarsPlugin {
                 }
                 entryFilesArray.forEach(sourcePath => {
                     try {
-                        this.compileEntryFile(sourcePath, compilation.compiler.outputPath);
+                        this.compileEntryFile(sourcePath, compilation.compiler.outputPath, compilation);
                     } catch (error) {
                         compilation.errors.push(new Error(`${sourcePath}: ${error.message}\n${error.stack}`));
                     }
@@ -306,8 +306,9 @@ class HandlebarsPlugin {
      * Generates the html file for the given filepath
      * @param  {String} sourcePath  - filepath to handelebars template
      * @param  {String} outputPath  - webpack output path for build results
+     * @param  {Object} compilation  - webpack compilation
      */
-    compileEntryFile(sourcePath, outputPath) {
+    compileEntryFile(sourcePath, outputPath, compilation) {
         outputPath = sanitizePath(outputPath);
 
         let rootFolderName = path.dirname(sourcePath);

--- a/utils/getTargetFilepath.js
+++ b/utils/getTargetFilepath.js
@@ -5,8 +5,9 @@ const sanitizePath = require("./sanitizePath");
 /**
  * Returns the target filePath of a handlebars template
  * @param  {String} filePath            - input filePath
- * @param  {String} [outputTemplate]    - template for output filename. If ommited, the same filename stripped of its extension will be used
- * @param  {String} [rootPath]            - input rootPath
+ * @param  {String} [outputTemplate]    - template for output filename. If ommited, the same filename stripped of its
+ *                                        extension will be used
+ * @param  {String} [rootPath]          - input rootPath
  * @return {String} target filePath
  */
 module.exports = function getTargetFilepath(filePath, outputTemplate, rootPath) {

--- a/utils/mergeJSON.js
+++ b/utils/mergeJSON.js
@@ -13,7 +13,4 @@ module.exports = function mergeJSON(absoluteGlobPattern) {
         resultingData[id] = require(filepath);
     });
     return resultingData;
-}
-
-
-
+};


### PR DESCRIPTION
This fixes a couple of path related issues for Windows:

- Watching file changes in `webpack-dev-server`. 
The filepath emitted to `webpack-dev-server` wasn't a correct path in the Windows system, as it was `C:/path/to/file` instead of `C:\\path\\to\\file`.

- Watching file changes on `html-webpack-plugin` partials in `webpack-dev-server`.
This was partially due to the issue above, but also as the file dependency path stored in `this.fileDependencies` for these partials were stored as Windows paths and then later checked up against sanitized paths. So this was fixed by using the `addDependency` method and using sanitizing the paths before adding them to the `fileDependencies`.

- Always seeing output path as **not** being part of the webpack destination folder. 
The output path was never a part of the `targetFilepath` as a sanitized path was being checked if it was included in a non-sanitized path. Thereby it went to the fallback and saved the compiled file directly in the webpack destination folder (using `fs.outputFileSync`) before webpack was ready to emit files. If you then had the `clean-webpack-plugin` installed the files would be deleted shortly after it was generated.

Let me know if there's something that needs to changed or updated.

This should hopefully fix the issue reported in #53 