### PR TITLE
Correct typ-oh in getPartialId function documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ To change the partial's id you can pass a custom partial-generator to the plugin
      * @return {String} hbs-partialId, per default folder/partialName is used
      */
     getPartialId: function (filePath) {
-        return path.match(/\/([^/]+\/[^/]+)\.[^.]+$/).pop();
+        return filePath.match(/\/([^/]+\/[^/]+)\.[^.]+$/).pop();
     }
 }
 ```


### PR DESCRIPTION
Fixing getPartialId function documentation so it works out of the box. I've kept the `filePath` variable as you've required the `path`  library throughout the documentation and this means that the function reads more clearly.

It should possibly use the regex from `utils/partials.js` but I'll leave that to your discretion.

```javascript
/* from README.md */
(/\/([^/]+\/[^/]+)\.[^.]+$/)
/* from utils/partials.js */
(/\/([^\/]+\/[^\/]+)\.[^\.]+$/)
```