### PR TITLE
Feature/#78

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ To change the partial's id you can pass a custom partial-generator to the plugin
 
 - the `HtmlWebpackPlugin` should be placed before the HandlebarsWebpackPlugin
 - multiple HtmlWebpackPlugins may be used
-- per default, the partials get registered to `html/<outputfilename>`, i.e. a filename `/dist/partials/head.hbs` will be registered as `html/head` to handlebars
+- per default, the partials get registered to `html/partials/<outputfilename>`, i.e. a filename `/dist/partials/head.hbs` will be registered as `html/partials/head` to handlebars
 
 
 ```js

--- a/index.js
+++ b/index.js
@@ -89,7 +89,6 @@ class HandlebarsPlugin {
 
         // COMPILE TEMPLATES
         const compile = (compilation, done) => {
-
             try {
                 // wp >= v5
                 if (compilation.fileTimestamps == null) {
@@ -136,7 +135,7 @@ class HandlebarsPlugin {
             const { enabled, HtmlWebpackPlugin } = this.options.htmlWebpackPlugin;
             // @feature html-webpack-plugin
             if (enabled && HtmlWebpackPlugin) {
-                compiler.hooks.compilation.tap("HtmlWebpackPluginHooks", compilation => {
+                compiler.hooks.thisCompilation.tap("HtmlWebpackPluginHooks", compilation => {
                     // html-webpack-plugin < 4
                     if (compilation.hooks.htmlWebpackPluginAfterHtmlProcessing) {
                         compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tap(
@@ -149,37 +148,44 @@ class HandlebarsPlugin {
                         HtmlWebpackPlugin.getHooks(compilation).beforeEmit
                             .tapAsync("HandlebarsRenderPlugin", (data, cb) => cb(null, this.processHtml(data)));
                     }
-                });
 
-                compiler.hooks.emit.tapAsync("HandlebarsRenderPlugin", (compilation, done) => {
-                    compile(compilation, () => emitDependencies(compilation, done));
+                    if (helperUtils.isWebpackV4(compilation)) {
+                        // @wp ^4.0.0
+                        compiler.hooks.emit.tapAsync("HandlebarsRenderPlugin", (_, done) => {
+                            compile(compilation, () => emitDependencies(compilation, done));
+                        });
+                    } else {
+                        // @wp >= 5
+                        compilation.hooks.processAssets.tapAsync(
+                            {
+                                name: "HandlebarsRenderPlugin",
+                                stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE
+                            },
+                            (assets, done) => {
+                                compile(compilation, () => emitDependencies(compilation, done));
+                            }
+                        );
+                    }
                 });
-
             } else {
                 // use standard compiler hooks
                 compiler.hooks.thisCompilation.tap("HandlebarsRenderPlugin", compilation => {
-                    if (typeof compilation.emitAsset !== "function") {
+                    if (helperUtils.isWebpackV4(compilation)) {
                         // @wp ^4.0.0
                         compiler.hooks.make.tapAsync("HandlebarsRenderPlugin", compile);
                         compiler.hooks.emit.tapAsync("HandlebarsRenderPlugin", emitDependencies);
-                        return;
+                    } else {
+                        // @wp >= 5
+                        compilation.hooks.processAssets.tapAsync(
+                            {
+                                name: "HandlebarsRenderPlugin",
+                                stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+                            },
+                            (assets, done) => {
+                                compile(compilation, () => emitDependencies(compilation, done));
+                            }
+                        );
                     }
-
-                    // @wp >= 5
-                    compilation.hooks.processAssets.tapAsync(
-                        {
-                            name: "HandlebarsRenderPlugin",
-                            stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_PRE_PROCESS
-                        },
-                        compile
-                    );
-                    compilation.hooks.processAssets.tapAsync(
-                        {
-                            name: "HandlebarsRenderPlugin",
-                            stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
-                        },
-                        emitDependencies
-                    );
                 });
             }
         } else {

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -3,6 +3,10 @@ const chalk = require("chalk");
 const log = require("./log");
 const path = require("path");
 
+function isWebpackV4(compilation) {
+    return typeof compilation.hooks.optimizeDependenciesBasic === "object" &&
+        compilation.hooks.optimizeDependenciesBasic !== null;
+}
 
 function getId(filepath) {
     const id = filepath.match(/\/([^/]*).js$/).pop();
@@ -62,6 +66,7 @@ function resolve(query) {
 
 
 module.exports = {
+    isWebpackV4,
     getId,
     register,
     unregister,


### PR DESCRIPTION
Ref: #78 
Tested with: 
- [x] `Webpack 5.11.0`, `Html-webpack-plugin 5.0.0-beta.1`
- [x] `Webpack 4.44.2`, `Html-webpack-plugin 4.5.0`

Hello, this PR fixed a DeprecationWarning with using Webpack v5. Please check this PR. Also need think about `package.json`, need update `peerDependencies` for `html-webpack-plugin`(if you use `npm v7` you can install only with `--legacy-peer-deps` flag).